### PR TITLE
Fix the geojson formatting problem

### DIFF
--- a/MojMapGML2GeoJSON.js
+++ b/MojMapGML2GeoJSON.js
@@ -78,9 +78,8 @@ class MojMapGML2GeoJSON {
 					properties: props,
 					type: "Feature",
 				};
-				geojs.features.push(ft);
+				geojsRoot.features.push(ft);
 			}
-			geojsRoot.features.push(geojs);
 		}
 		return geojsRoot;
 	}


### PR DESCRIPTION
生成される GeoJSON のフォーマットが以下のように `FeatureCollection` がネストした状態になっているのでその修正です。

```
{
  "type": "FeatureCollection",
  "features": [
      {
        "type": "FeatureCollection",
        "features": []
      }
   ]
}
```